### PR TITLE
pretty missing from build-depends; and cabal-install can't handle ghc dep

### DIFF
--- a/GenericPretty.cabal
+++ b/GenericPretty.cabal
@@ -86,7 +86,7 @@ Library
   Exposed-modules:     Text.PrettyPrint.GenericPretty
   
   -- Packages needed in order to build this package.
-  Build-depends: 	   base >= 3 && < 5, ghc-prim, ghc >= 7.4
+  Build-depends: 	   base >= 3 && < 5, ghc-prim, pretty
   
   -- Modules not exported by this package.
   -- Other-modules:       


### PR DESCRIPTION
pretty missing from build-depends; and cabal-install can't handle ghc dep

I have ghc 7.4.1 but the ghc >= 7.4 dep here makes cabal-install freak
out.  I think in general cabal-install is too much of a mess to have ghc
deps.

Resolving dependencies...
cabal: Could not resolve dependencies:
trying: GenericPretty-1.2.0 (user goal)
trying: ghc-7.4.1/installed-2e8... (dependency of GenericPretty-1.2.0)
next goal: containers (dependency of ghc-7.4.1/installed-2e8...)
rejecting: containers-0.5.0.0/installed-35f..., 0.4.2.1/installed-98f...
(conflict: ghc => containers==0.4.2.1/installed-cfc...)
trying: containers-0.4.2.1/installed-cfc...
next goal: deepseq (dependency of containers-0.4.2.1/installed-cfc...)
rejecting: deepseq-1.3.0.0/installed-a73... (conflict: ghc =>
array==0.4.0.0/installed-59d..., deepseq =>
array==0.4.0.0/installed-46f...)
rejecting: deepseq-1.3.0.1, 1.3.0.0, 1.2.0.1, 1.2.0.0, 1.1.0.2, 1.1.0.1,
1.1.0.0, 1.0.0.0 (conflict: containers =>
deepseq==1.3.0.0/installed-a73...)
