### PR TITLE
Add instance Out for Text since it is in ghc now

### DIFF
--- a/GenericPretty.cabal
+++ b/GenericPretty.cabal
@@ -7,7 +7,7 @@ Name:                GenericPretty
 -- The package version. See the Haskell package versioning policy
 -- (http://www.haskell.org/haskellwiki/Package_versioning_policy) for
 -- standards guiding when and how versions should be incremented.
-Version:             1.2.2
+Version:             1.2.3
 
 -- A short (one-line) description of the package.
 Synopsis:            A generic, derivable, haskell pretty printer.
@@ -86,7 +86,7 @@ Library
   Exposed-modules:     Text.PrettyPrint.GenericPretty
   
   -- Packages needed in order to build this package.
-  Build-depends: 	   base >= 3 && < 5, ghc-prim, pretty
+  Build-depends: 	   base >= 3 && < 5, ghc-prim, pretty, text
   
   -- Modules not exported by this package.
   -- Other-modules:       

--- a/README
+++ b/README
@@ -54,9 +54,9 @@ If you have cabal, you can simply do:
 Otherwise, the steps are:
   0. Make sure you have a version of ghc >= 7.4 installed and that you can 
      use the 'runhaskell' command from the command line.
-  1. Download and unpack "GenericPretty-1.2.2.tar.gz"
+  1. Download and unpack "GenericPretty-1.2.3.tar.gz"
   2. Move to the correct directory:
-      $ cd GenericPretty-1.2.2
+      $ cd GenericPretty-1.2.3
   3. Run the following haskell commands to install the library globally:
       $ runhaskell Setup configure 
       $ runhaskell Setup build

--- a/Text/PrettyPrint/GenericPretty.hs
+++ b/Text/PrettyPrint/GenericPretty.hs
@@ -29,9 +29,10 @@ module Text.PrettyPrint.GenericPretty
 -- Avoid name clash with Prelude.<> exported by post-SMP versions of base.
 import Prelude hiding ( (<>) )
 #endif
-import Data.List
-import GHC.Generics
 import Data.Char
+import Data.List
+import Data.Text (Text, unpack)
+import GHC.Generics
 import Text.PrettyPrint
 
 -- | The class 'Out' is the equivalent of 'Prelude.Show'
@@ -406,6 +407,10 @@ instance Out Bool where
     doc True = text "True"
     doc False = text "False"
     docPrec _ = doc
+
+instance Out Text where
+  doc = doc . unpack
+  docPrec n = docPrec n . unpack
 
 instance Out a => Out (Maybe a) where
   docPrec n Nothing = text "Nothing"


### PR DESCRIPTION
Incremented the patch level version number to 1.2.3 so that it's easy
to push to hackage.